### PR TITLE
Alter telegram_userid type from i64 to String

### DIFF
--- a/.sqlx/query-361cba2a4dfed276a1a1a5285d98faf9c4bc74f27309f7f4bd590fab0f2cf9c0.json
+++ b/.sqlx/query-361cba2a4dfed276a1a1a5285d98faf9c4bc74f27309f7f4bd590fab0f2cf9c0.json
@@ -11,7 +11,7 @@
     ],
     "parameters": {
       "Left": [
-        "Int8"
+        "Text"
       ]
     },
     "nullable": [

--- a/.sqlx/query-5a3d0c9d6fc2abb00f55f0815326ab31fcabe74adf4eb3d6d20af3ca7d6e54dd.json
+++ b/.sqlx/query-5a3d0c9d6fc2abb00f55f0815326ab31fcabe74adf4eb3d6d20af3ca7d6e54dd.json
@@ -11,7 +11,7 @@
       {
         "ordinal": 1,
         "name": "telegram_userid",
-        "type_info": "Int8"
+        "type_info": "Varchar"
       },
       {
         "ordinal": 2,
@@ -27,7 +27,7 @@
     "parameters": {
       "Left": [
         "Text",
-        "Int8",
+        "Text",
         "Text"
       ]
     },

--- a/.sqlx/query-6f89962823361c56de89197f98752f621258fc4360146302b812ad0385374ffa.json
+++ b/.sqlx/query-6f89962823361c56de89197f98752f621258fc4360146302b812ad0385374ffa.json
@@ -11,7 +11,7 @@
       {
         "ordinal": 1,
         "name": "telegram_userid",
-        "type_info": "Int8"
+        "type_info": "Varchar"
       },
       {
         "ordinal": 2,

--- a/.sqlx/query-fec91934b8594955965fadaf4c1bc0874e9e209b2dde1ef6515224561e477ede.json
+++ b/.sqlx/query-fec91934b8594955965fadaf4c1bc0874e9e209b2dde1ef6515224561e477ede.json
@@ -5,7 +5,7 @@
     "columns": [],
     "parameters": {
       "Left": [
-        "Int8",
+        "Varchar",
         "Varchar",
         "Varchar"
       ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telerun"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 license = "MIT"
 description = "Rust telegram bot for tracking runs."
@@ -12,8 +12,8 @@ publish = true
 
 [dependencies]
 log = "0.4"
-pretty_env_logger = "0.4"
-shuttle-runtime = "0.24.0"
+pretty_env_logger = "0.5"
+shuttle-runtime = "0.29.0"
 tokio = { version = "1.26.0" }
 sqlx = { version = "0.7.1", features = [
   "runtime-tokio-native-tls",
@@ -22,8 +22,8 @@ sqlx = { version = "0.7.1", features = [
   "chrono",
 ] }
 teloxide = { version = "0.12.0", features = ["macros"] }
-shuttle-shared-db = { version = "0.24.0", features = ["postgres", "sqlx"] }
-shuttle-secrets = "0.24.0"
+shuttle-shared-db = { version = "0.29.0", features = ["postgres", "sqlx"] }
+shuttle-secrets = "0.29.0"
 reqwest = "0.11.18"
 askama = "0.12.0"
 tracing = "0.1.37"

--- a/migrations/20231010143842_schema.sql
+++ b/migrations/20231010143842_schema.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE users ALTER COLUMN telegram_userid TYPE varchar(20) USING telegram_userid::varchar(20);

--- a/src/database.rs
+++ b/src/database.rs
@@ -87,7 +87,7 @@ pub async fn get_users_in_chat(
     .iter()
     .map(|user_row| User {
         id: user_row.id,
-        telegram_userid: user_row.telegram_userid,
+        telegram_userid: user_row.telegram_userid.clone(),
         chat_id: user_row.chat_id.clone(),
         user_name: user_row.user_name.clone(),
     })

--- a/src/message.rs
+++ b/src/message.rs
@@ -46,7 +46,11 @@ impl fmt::Display for User {
 
 impl fmt::Display for Score {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}", self.user_name, self.medals, self.distance)
+        write!(
+            f,
+            "{} {}🏅 {}km",
+            self.user_name, self.medals, self.distance
+        )
     }
 }
 
@@ -147,7 +151,6 @@ mod tests {
             },
         ];
         let render = list_runs(Some(runs));
-        // TODO: i actually dont want this kind of html templates anyway
         let ans = "#. RunID Distance RunTime
 1. 1 1 1970-01-01 00:01:01 1
 2. 2 2 1970-01-01 00:01:22 2
@@ -168,13 +171,13 @@ mod tests {
         let users = vec![
             User {
                 id: 1,
-                telegram_userid: 1,
+                telegram_userid: 1.to_string(),
                 chat_id: "chat1".into(),
                 user_name: "meme".into(),
             },
             User {
                 id: 2,
-                telegram_userid: 2,
+                telegram_userid: 2.to_string(),
                 chat_id: "chat1".into(),
                 user_name: "youyou".into(),
             },
@@ -226,11 +229,11 @@ mod tests {
         ];
         let render = display_tally(Some(scores));
         let ans = "#. UserName Medals Distance (km)
-🥇 1. reuben 5 20
-🥈 2. milton 2 10
-🥉 3. jerrell 1 1
-🏃 4. taigy 1 0.2
-🤡 5. riley 2 0.1
+🥇 1. reuben 5🏅 20km
+🥈 2. milton 2🏅 10km
+🥉 3. jerrell 1🏅 1km
+🏃 4. taigy 1🏅 0.2km
+🤡 5. riley 2🏅 0.1km
 ";
         assert_eq!(render, ans);
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,7 +14,7 @@ pub struct User {
     /// PostgreSQL does not natively support u64 values,
     /// and thus we will attempt to cast the values from Telegram
     /// as i64 first before storing in DB.
-    pub telegram_userid: i64,
+    pub telegram_userid: String,
     /// Id of telegram chat
     pub chat_id: String,
     /// Self-specified username


### PR DESCRIPTION
The `UserId` type is actually implemented as a `u64`. Postgres does not support `u64` and I had stored it as an `i64`. However, this risks newer accounts having issues with the bot. I am thus storing them as `String`s instead.