### PR TITLE
Pin stable versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,5 +13,6 @@ jobs:
       - uses: shuttle-hq/deploy-action@main
         with:
           deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+          cargo-shuttle-version: "0.24.0"
           secrets: |
             TELOXIDE_TOKEN = '${{ secrets.TELOXIDE_TOKEN }}'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telerunbot"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 license = "MIT"
 description = "Rust telegram bot for tracking runs."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ publish = true
 
 [dependencies]
 log = "0.4"
-pretty_env_logger = "0.5"
-shuttle-runtime = "0.29.0"
+pretty_env_logger = "0.4"
+shuttle-runtime = "0.24.0"
 tokio = { version = "1.26.0" }
 sqlx = { version = "0.7.1", features = [
   "runtime-tokio-native-tls",
@@ -22,8 +22,8 @@ sqlx = { version = "0.7.1", features = [
   "chrono",
 ] }
 teloxide = { version = "0.12.0", features = ["macros"] }
-shuttle-shared-db = { version = "0.29.0", features = ["postgres", "sqlx"] }
-shuttle-secrets = "0.29.0"
+shuttle-shared-db = { version = "0.24.0", features = ["postgres", "sqlx"] }
+shuttle-secrets = "0.24.0"
 reqwest = "0.11.18"
 askama = "0.12.0"
 tracing = "0.1.37"


### PR DESCRIPTION
Dependencies pinned to `0.24.0` and deploy-action is pinned to the same version.